### PR TITLE
Initial checkin of rna-summarization (featureCounts) workflow.

### DIFF
--- a/rna/rna-summarization/README.md
+++ b/rna/rna-summarization/README.md
@@ -1,0 +1,26 @@
+# RNASummarization with subread featureCounts
+
+This workflow runs the subread featureCounts command on a BAM file
+(http://subread.sourceforge.net/).
+
+Inputs:
+- Per-sample:
+  - Sample Name
+  - BAM file
+
+- Reference:
+  - Gene map (GTF) file
+
+- VM configuration
+  - Docker image url
+  - VM disk size
+  - VM memory
+  - Num CPU cores
+  - Runtime zones, ex: "us-central1-c us-central1-b"
+  - Number of times to try the workflow with a preemptible VM before
+    falling back to a full-price VM.
+
+Outputs:
+- Per-sample
+  - &lt;sample_name&gt;.featureCounts.tsv
+  - &lt;sample_name&gt;.featureCounts.tsv.summary

--- a/rna/rna-summarization/README.md
+++ b/rna/rna-summarization/README.md
@@ -24,3 +24,10 @@ Outputs:
 - Per-sample
   - &lt;sample_name&gt;.featureCounts.tsv
   - &lt;sample_name&gt;.featureCounts.tsv.summary
+
+## Notes
+A sample inputs.json file is included here with values derived from running workflows for AMP PD on [Terra.](https://app.terra.bio/)
+
+The gene map (GTF) file used was [GENCODE](https://www.gencodegenes.org/) v29.
+
+The `subread` Docker image used was from [BioContainers](https://biocontainers.pro).

--- a/rna/rna-summarization/README.md
+++ b/rna/rna-summarization/README.md
@@ -16,7 +16,7 @@ Inputs:
   - VM disk size
   - VM memory
   - Num CPU cores
-  - Runtime zones, ex: "us-central1-c us-central1-b"
+  - Runtime zones, ex: "us-central1-a us-central1-b"
   - Number of times to try the workflow with a preemptible VM before
     falling back to a full-price VM.
 

--- a/rna/rna-summarization/rna-summarization.inputs.json
+++ b/rna/rna-summarization/rna-summarization.inputs.json
@@ -16,5 +16,5 @@
 
   "##_COMMENT5": "Would be unusual to take more than 24 hours, so use preemptible",
   "RNASummarization.num_preemptible_retries": 5,
-  "RNASummarization.runtime_zones": "us-central1-a, us-central1-b"
+  "RNASummarization.runtime_zones": "us-central1-a us-central1-b"
 }

--- a/rna/rna-summarization/rna-summarization.inputs.json
+++ b/rna/rna-summarization/rna-summarization.inputs.json
@@ -15,6 +15,6 @@
   "RNASummarization.featureCounts_vm_disk_size_gb": 1000,
 
   "##_COMMENT5": "Would be unusual to take more than 24 hours, so use preemptible",
-  "RNASummarization.num_preemptible_retries": 5,
+  "RNASummarization.preemptible_tries": 5,
   "RNASummarization.runtime_zones": "us-central1-a us-central1-b"
 }

--- a/rna/rna-summarization/rna-summarization.inputs.json
+++ b/rna/rna-summarization/rna-summarization.inputs.json
@@ -1,0 +1,20 @@
+{
+  "##_COMMENT1": "Set your per-sample values: name and BAM path",
+  "RNASummarization.sample_name": "__INSERT_SAMPLE_NAME__",
+  "RNASummarization.bam_file": "__INSERT_GCS_PATH_TO_BAM_FILE__",
+
+  "##_COMMENT2": "Path to the reference GTF file",
+  "RNASummarization.gene_map": "gs://amp-pd-transcriptomics/inputs/reference/gencode/gencode.v29.primary_assembly.annotation.gtf.gz",
+
+  "##_COMMENT3": "Path to a Docker image containing subread",
+  "RNASummarization.featureCounts_docker": "quay.io/biocontainers/subread:1.6.3--h84994c4_1",
+
+  "##_COMMENT4": "For large BAMs, you might need to allocate more resources",
+  "RNASummarization.num_cpu_cores": 2,
+  "RNASummarization.featureCounts_vm_memory": "7.5GB",
+  "RNASummarization.featureCounts_vm_disk_size_gb": 1000,
+
+  "##_COMMENT5": "Would be unusual to take more than 24 hours, so use preemptible",
+  "RNASummarization.num_preemptible_retries": 5,
+  "RNASummarization.runtime_zones": "us-central1-a, us-central1-b"
+}

--- a/rna/rna-summarization/rna-summarization.wdl
+++ b/rna/rna-summarization/rna-summarization.wdl
@@ -76,10 +76,15 @@ task subread_featureCounts {
     set -o nounset
     set -o pipefail
 
+    # Set the output file name
     OUTPUT="$(pwd)/${sample_name}.featureCounts.tsv"
+
+    # Unzip the gene map
     gunzip "${gene_map}"
     UNZIPPED_GENE_MAP="$(echo ${gene_map} | sed -e "s/.gz$//")"
 
+    # Run featureCounts in the directory with the BAM; 
+    # otherwise the output file records the full path in the header
     cd $(dirname "${bam_file}")
 
     featureCounts \

--- a/rna/rna-summarization/rna-summarization.wdl
+++ b/rna/rna-summarization/rna-summarization.wdl
@@ -36,7 +36,7 @@ workflow RNASummarization {
   String featureCounts_vm_memory
   Int num_cpu_cores
   String runtime_zones
-  Int num_preemptible_retries
+  Int preemptible_tries
 
   call subread_featureCounts {
     input:
@@ -49,7 +49,7 @@ workflow RNASummarization {
       featureCounts_vm_disk_size_gb = featureCounts_vm_disk_size_gb,
       num_cpu_cores = num_cpu_cores,
       runtime_zones = runtime_zones,
-      num_preemptible_retries = num_preemptible_retries,
+      preemptible_tries = preemptible_tries,
       featureCounts_vm_memory = featureCounts_vm_memory
    }
 
@@ -68,7 +68,7 @@ task subread_featureCounts {
   Int featureCounts_vm_disk_size_gb
   Int num_cpu_cores
   String runtime_zones
-  Int num_preemptible_retries
+  Int preemptible_tries
   String featureCounts_vm_memory
 
   command {
@@ -102,7 +102,7 @@ task subread_featureCounts {
 
     disks: "local-disk " + featureCounts_vm_disk_size_gb + " HDD"
     zones: runtime_zones
-    preemptible: num_preemptible_retries
+    preemptible: preemptible_tries
     memory: featureCounts_vm_memory
     cpu: num_cpu_cores
   }

--- a/rna/rna-summarization/rna-summarization.wdl
+++ b/rna/rna-summarization/rna-summarization.wdl
@@ -81,7 +81,7 @@ task subread_featureCounts {
 
     # Unzip the gene map
     gunzip "${gene_map}"
-    UNZIPPED_GENE_MAP="$(echo ${gene_map} | sed -e "s/.gz$//")"
+    UNZIPPED_GENE_MAP="$(echo ${gene_map} | sed -e 's/.gz$//')"
 
     # Run featureCounts in the directory with the BAM; 
     # otherwise the output file records the full path in the header


### PR DESCRIPTION
Similar to Matt's PR [here](https://github.com/amp-pd/amp-pd-workflows/pull/1) with a change to the zipped gene_map file. 

Tested in our test workspace. Verified featureCounts ran before aborting workflow.

Fixes #5 . 